### PR TITLE
Only update field value when touchstart/mousedown.

### DIFF
--- a/acf-signature/js/input.js
+++ b/acf-signature/js/input.js
@@ -18,7 +18,8 @@
             canvas = canvasObj[0],
             inputObj = wrapper.find("input"),
             input = inputObj[0],
-            signaturePad;
+            signaturePad,
+	    touched = false;
         
         console.log(canvas);
         
@@ -41,7 +42,7 @@
 
         var data = $(input).val();
         if ( data.length ) {
-            console.log(data);
+            // console.log(data);
             signaturePad.fromDataURL( data );
         }
 
@@ -50,12 +51,18 @@
             signaturePad.clear();
             $(input).val('');
         });
+		
+	$(canvas).on("touchstart mousedown", function(event){
+	    touched = true;
+	});
 
         $(canvas).on("touchend mouseup mouseleave", function(event) {
             if ( signaturePad.isEmpty() ) {
                 $(input).val('');
             } else {
-                $(input).val(signaturePad.toDataURL());
+	        if(touched){
+                    $(input).val(signaturePad.toDataURL());
+		}
             }
         });
 	}


### PR DESCRIPTION
This solves the issue with the field value being updated without a touch occurring. After closer inspection, I believe the changes were being triggered by the "mouseleave" event which, while important to signify a possible end of writing, doesn't indicate on it's own that writing has occurred.